### PR TITLE
Get post by id route

### DIFF
--- a/__test__/integrationTests.test.ts
+++ b/__test__/integrationTests.test.ts
@@ -500,16 +500,50 @@ describe("Integration tests for POST routes:", () => {
     });
 
     describe("/api/posts/getPostById", () => {
-        test("responds with 200 ok and the post with comments, likes and tags with valid inputs", () => {
-            expect(true).toBe(true);
-        })
+        test("responds with 200 ok and the post with comments, likes and tags with valid inputs", async () => {
+            // Create a user
+            const user = await axios.post("/api/auth/register", {
+                userName: "getPostByIdUser",
+                email: "post@email.com",
+                password: "Abc-1234",
+            });
+            expect(await db.user.count()).toBe(1);
 
-        // Tests for get post
+            // Create some tags in the database
+            await db.tag.createMany({
+                data: [{ name: "JS" }, { name: "TS" }, { name: "GraphQL" }],
+            });
+            expect(await db.tag.count()).toBe(3);
+
+            // Create a post in the database
+            const post = await db.post.createPost({
+                userId: user?.data?.data?.id,
+                title: "test",
+                content: "test",
+                status: "DRAFT",
+                category: "GENERAL",
+                postTags: ["JS"],
+            });
+            expect(await db.post.count()).toBe(1);
+
+            const response = await axios.post("/api/posts/getPostById", {
+                postId: post?.id,
+            });
+            expect(response.status).toBe(200);
+            expect(response.data.data.id).toBe(post?.id);
+            expect(response.data.data.postTags[0].tag.name).toBe("JS");
+        });
+
+        test("responds with 400 Bad Request when post not in database", async () => {
+            // Don't create a post in the database for this test
+            const response = await axios.post("/api/posts/getPostById", {
+                postId: "5e8f8f8f8f8f8f8f8f8f8f8",
+            });
+            expect(response.status).toBe(400);
+        });
+
+        // Tests for get post by id
         // validation tests 400 error with invalid inputs
-        // 400 when post doesn't exist
-        // 200 when ok
-        // can get post by id when not logged in
-    })
+        // TODO: check that comments and likes are present in 200 OK test
+    });
 });
-
-

--- a/__test__/integrationTests.test.ts
+++ b/__test__/integrationTests.test.ts
@@ -496,7 +496,20 @@ describe("Integration tests for POST routes:", () => {
             });
             expect(response.status).toBe(401);
         });
+        // returns 400 error with invalid inputs - validation tests
     });
+
+    describe("/api/posts/getPostById", () => {
+        test("responds with 200 ok and the post with comments, likes and tags with valid inputs", () => {
+            expect(true).toBe(true);
+        })
+
+        // Tests for get post
+        // validation tests 400 error with invalid inputs
+        // 400 when post doesn't exist
+        // 200 when ok
+        // can get post by id when not logged in
+    })
 });
 
-// returns 400 error with invalid inputs - validation tests
+

--- a/app.ts
+++ b/app.ts
@@ -58,7 +58,7 @@ const app = (store: PrismaSessionStore): Express => {
     server.use("/api/posts", postRoutes);
     server.use("/api/user", userRoutes);
 
-    server.use("/", (req, res) => {
+    server.get("/", (req, res) => {
         return res.status(200).json({
             status: "success",
             message: "This is the web service API for the DevPrep project",

--- a/controllers/__test__/postController.test.ts
+++ b/controllers/__test__/postController.test.ts
@@ -127,7 +127,7 @@ describe("Unit Tests for Post Controllers", () => {
     // -------------------------------------------------------------------------
     describe("GetPostById Controller:", () => {
         test("returns a function", () => {
-            const mockDBGetPostById = jest.fn()
+            const mockDBGetPostById = jest.fn();
             expect(typeof getPostById(mockDBGetPostById)).toBe("function");
         });
 
@@ -140,17 +140,22 @@ describe("Unit Tests for Post Controllers", () => {
             const { res, next } = getMockRes();
             await getPostById(mockDBGetPostById)(req, res, next);
             expect(res.status).toHaveBeenCalledWith(200);
-            expect(res.json).toHaveBeenCalledWith({ status: "success", data: mockPost });
+            expect(res.json).toHaveBeenCalledWith({
+                status: "success",
+                data: mockPost,
+            });
         });
 
         test("passes correct data to db.post.getPostById", async () => {
-            const mockDBGetPostById = jest.fn()
+            const mockDBGetPostById = jest.fn();
             const req = getMockReq({
                 postId: "test",
             });
             const { res, next } = getMockRes();
             await getPostById(mockDBGetPostById)(req, res, next);
-            expect(jest.mocked(mockDBGetPostById).mock.calls[0][0]).toBe(req.body.postId);
+            expect(jest.mocked(mockDBGetPostById).mock.calls[0][0]).toBe(
+                req.body.postId
+            );
         });
 
         test("returns 400 Bad Request if post doesn't exist", async () => {
@@ -166,7 +171,7 @@ describe("Unit Tests for Post Controllers", () => {
         test("calls next() if an error occurs", async () => {
             const mockDBGetPostById = jest.fn().mockImplementation(() => {
                 throw new Error("error");
-            })
+            });
             const req = getMockReq({
                 postId: "test",
             });
@@ -174,7 +179,5 @@ describe("Unit Tests for Post Controllers", () => {
             await getPostById(mockDBGetPostById)(req, res, next);
             expect(next).toHaveBeenCalledWith(new Error("error"));
         });
-
-        // getPostById Validation tests
     });
 });

--- a/controllers/postController.ts
+++ b/controllers/postController.ts
@@ -40,3 +40,14 @@ export const createPost =
             return next(error);
         }
     };
+
+export const getPostById = (DBGetPostById: PostMethods.GetPostById): RequestHandler => async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const result = await DBGetPostById(req.body.postId);
+        if(!result) return res.status(400).json({ status: "error", message: "Post not found" });
+        
+        return res.status(200).json({ status: "success", data: result });
+    } catch (error) {
+        return next(error);
+    }
+}

--- a/controllers/postController.ts
+++ b/controllers/postController.ts
@@ -41,13 +41,18 @@ export const createPost =
         }
     };
 
-export const getPostById = (DBGetPostById: PostMethods.GetPostById): RequestHandler => async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        const result = await DBGetPostById(req.body.postId);
-        if(!result) return res.status(400).json({ status: "error", message: "Post not found" });
-        
-        return res.status(200).json({ status: "success", data: result });
-    } catch (error) {
-        return next(error);
-    }
-}
+export const getPostById =
+    (DBGetPostById: PostMethods.GetPostById): RequestHandler =>
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const result = await DBGetPostById(req.body.postId);
+            if (!result)
+                return res
+                    .status(400)
+                    .json({ status: "error", message: "Post not found" });
+
+            return res.status(200).json({ status: "success", data: result });
+        } catch (error) {
+            return next(error);
+        }
+    };

--- a/models/__test__/db.test.ts
+++ b/models/__test__/db.test.ts
@@ -22,6 +22,7 @@ describe("Unit Tests for Database Object:", () => {
         expect(typeof db.post).toBe("object");
         expect(db.post.count).toBeDefined();
         expect(db.post.createPost).toBeDefined();
+        expect(db.post.getPostById).toBeDefined();
     });
 
     test("contains tag object with default methods", () => {

--- a/models/__test__/postModel.test.ts
+++ b/models/__test__/postModel.test.ts
@@ -1,4 +1,5 @@
 import db from "../db";
+import { UserWithoutPassword } from "../../models/userModel";
 
 jest.mock("../prisma");
 
@@ -12,16 +13,17 @@ describe("Unit Tests for Post Model:", () => {
 
     test("returns an object with custom methods", () => {
         expect(posts.create).toBeDefined();
+        expect(posts.getPostById).toBeDefined();
     });
 
     describe("Custom Methods:", () => {
-        // Create post
-        // -------------------------------------------------------------------------
-        test("post.create creates a new post in the database", async () => {
-            expect(await posts.count()).toBe(0);
+        let user: UserWithoutPassword;
 
+        beforeEach(async () => {
+            // Note: There is no need to clear the database between tests as the
+            // prisma mock already does this
             // Create a user in the database
-            const user = await db.user.register({
+            user = await db.user.register({
                 userName: "test",
                 email: "test@email.com",
                 password: "testPassword",
@@ -30,9 +32,22 @@ describe("Unit Tests for Post Model:", () => {
 
             // Create some tags in the database
             await db.tag.createMany({
-                data: [{ name: "JS" }, { name: "TS" }, { name: "GraphQL" }],
+                data: [
+                    { name: "JS" },
+                    { name: "TS" },
+                    { name: "GraphQL" },
+                    { name: "React" },
+                    { name: "Vue" },
+                    { name: "Java" },
+                ],
             });
-            expect(await db.tag.count()).toBe(3);
+            expect(await db.tag.count()).toBe(6);
+        });
+
+        // Create post
+        // -------------------------------------------------------------------------
+        test("post.create creates a new post in the database", async () => {
+            expect(await posts.count()).toBe(0);
 
             await posts.createPost({
                 userId: user.id,
@@ -58,5 +73,55 @@ describe("Unit Tests for Post Model:", () => {
             });
             expect(result?.postTags.length).toBe(2);
         });
+
+        // Get post by id
+        // -------------------------------------------------------------------------
+        test("post.getPostById returns the correct post with associated tags, comments and likes", async () => {
+            expect(await posts.count()).toBe(0);
+
+            // Create some posts in the database
+            const post1 = await posts.createPost({
+                userId: user.id,
+                title: "test",
+                content: "test",
+                status: "PUBLISHED",
+                category: "GENERAL",
+                postTags: ["Vue", "Java"],
+            });
+
+            const post2 = await posts.createPost({
+                userId: user.id,
+                title: "test",
+                content: "test",
+                status: "PUBLISHED",
+                category: "GENERAL",
+                postTags: ["JS", "TS"],
+            });
+            expect(await posts.count()).toBe(2);
+            expect(post1?.id).not.toEqual(post2?.id);
+
+            // Get post1 by id
+            const result = await posts.getPostById(post1?.id as string);
+            expect(result?.id).toBe(post1?.id);
+
+            // Check that tags are included
+            expect(result?.postTags.length).toBe(2);
+            expect(result?.comments.length).toBe(0);
+            expect(result?.likes.length).toBe(0);
+        });
+
+        test("post.getpostById returns null if the post does not exist", async () => {
+            // Don't create any posts in the database for this test
+            expect(await posts.count()).toBe(0);
+
+            // Try to get a post by id
+            const result = await posts.getPostById("not-a-valid-id");
+            expect(result).toBeNull();
+        });
     });
 });
+
+// TODO:
+// Should return all related comments
+// Should return all related likes
+//

--- a/models/__test__/postModel.test.ts
+++ b/models/__test__/postModel.test.ts
@@ -108,6 +108,7 @@ describe("Unit Tests for Post Model:", () => {
             expect(result?.postTags.length).toBe(2);
             expect(result?.comments.length).toBe(0);
             expect(result?.likes.length).toBe(0);
+            console.log(result?.postTags)
         });
 
         test("post.getpostById returns null if the post does not exist", async () => {

--- a/models/__test__/postModel.test.ts
+++ b/models/__test__/postModel.test.ts
@@ -108,7 +108,6 @@ describe("Unit Tests for Post Model:", () => {
             expect(result?.postTags.length).toBe(2);
             expect(result?.comments.length).toBe(0);
             expect(result?.likes.length).toBe(0);
-            console.log(result?.postTags)
         });
 
         test("post.getpostById returns null if the post does not exist", async () => {

--- a/models/__test__/userModel.test.ts
+++ b/models/__test__/userModel.test.ts
@@ -141,6 +141,7 @@ describe("Unit Tests for User Model:", () => {
             expect(user?.userName).toBe("jeff");
             expect(user?.id).toBe(jeff?.id);
         });
+
         test("Should be unable to getUserById on an id that doesn't exist", async () => {
             // It's important to check if the error this causes breaks our app or not
             const binChicken = await users.getUserById(

--- a/models/postModel.ts
+++ b/models/postModel.ts
@@ -23,7 +23,7 @@ const Posts = (prismaPost: PrismaClient["post"]) => {
         getPostById: (id) => {
             return prismaPost.findUnique({
                 where: {
-                    id: id,
+                    id: id
                 },
                 include: {
                     postTags: {
@@ -33,8 +33,8 @@ const Posts = (prismaPost: PrismaClient["post"]) => {
                     },
                     comments: true,
                     likes: true,
-                },
-            });
+                }
+            })
         },
     };
 
@@ -70,10 +70,10 @@ export interface PostData {
 
 // Define type for posts including relationships to tags, likes and comments
 const postWithRelations = Prisma.validator<Prisma.PostArgs>()({
-    include: {
-        postTags: { include: { tag: true } },
+    include: { 
+        postTags: { include: { tag: true }},
         comments: true,
         likes: true,
-    },
+     }
 });
-export type PostWithRetations = Prisma.PostGetPayload<typeof postWithRelations>;
+export type PostWithRetations = Prisma.PostGetPayload<typeof postWithRelations>

--- a/models/postModel.ts
+++ b/models/postModel.ts
@@ -23,7 +23,7 @@ const Posts = (prismaPost: PrismaClient["post"]) => {
         getPostById: (id) => {
             return prismaPost.findUnique({
                 where: {
-                    id: id
+                    id: id,
                 },
                 include: {
                     postTags: {
@@ -33,8 +33,8 @@ const Posts = (prismaPost: PrismaClient["post"]) => {
                     },
                     comments: true,
                     likes: true,
-                }
-            })
+                },
+            });
         },
     };
 
@@ -70,10 +70,10 @@ export interface PostData {
 
 // Define type for posts including relationships to tags, likes and comments
 const postWithRelations = Prisma.validator<Prisma.PostArgs>()({
-    include: { 
-        postTags: { include: { tag: true }},
+    include: {
+        postTags: { include: { tag: true } },
         comments: true,
         likes: true,
-     }
+    },
 });
-export type PostWithRetations = Prisma.PostGetPayload<typeof postWithRelations>
+export type PostWithRetations = Prisma.PostGetPayload<typeof postWithRelations>;

--- a/routes/postRoutes.ts
+++ b/routes/postRoutes.ts
@@ -3,7 +3,7 @@ import db from "../models/db";
 import protect from "../middleware/routeProtector";
 
 // Import controllers
-import { createPost } from "../controllers/postController";
+import { createPost, getPostById } from "../controllers/postController";
 
 const router = express.Router();
 
@@ -13,5 +13,7 @@ router
         protect({ loggedIn: true }),
         createPost(db.tag.getAllTags, db.post.createPost)
     );
+
+router.route("/getPostById").post(getPostById(db.post.getPostById));
 
 export default router;


### PR DESCRIPTION
Added a route to get a post by post id. This will return the post and the associated tags, likes and comments (but not replies to comments - this will be added later once comments have been added to the backend api)