### PR TITLE
Jacob delete post

### DIFF
--- a/__test__/integrationTests.test.ts
+++ b/__test__/integrationTests.test.ts
@@ -458,16 +458,16 @@ describe("Integration tests for POST routes:", () => {
             });
             expect(loginResponse.status).toBe(200);
 
+            // Get session cookie
+            if (!loginResponse.headers["set-cookie"])
+                throw new Error("No cookie set");
+            const cookie: string = loginResponse.headers["set-cookie"][0];
+
             // Create some tags in the database
             await db.tag.createMany({
                 data: [{ name: "JS" }, { name: "TS" }, { name: "GraphQL" }],
             });
             expect(await db.tag.count()).toBe(3);
-
-            // Get session cookie
-            if (!loginResponse.headers["set-cookie"])
-                throw new Error("No cookie set");
-            const cookie: string = loginResponse.headers["set-cookie"][0];
 
             const response = await axios({
                 url: "/api/posts/create",
@@ -545,5 +545,104 @@ describe("Integration tests for POST routes:", () => {
         // Tests for get post by id
         // validation tests 400 error with invalid inputs
         // TODO: check that comments and likes are present in 200 OK test
+    });
+
+    describe("/api/posts/deletePost", () => {
+        test("responds with 200 OK and the deleted post if successful", async () => {
+            // Create a user
+            const user = await axios.post("/api/auth/register", {
+                userName: "deletepostUser",
+                email: "delete@email.com",
+                password: "Abc-1234",
+            });
+            expect(await db.user.count()).toBe(1);
+
+            // Log the user in
+            const loginResponse = await axios.post("/api/auth/login", {
+                email: "delete@email.com",
+                password: "Abc-1234",
+            });
+            expect(loginResponse.status).toBe(200);
+
+            // Get session cookie
+            if (!loginResponse.headers["set-cookie"])
+                throw new Error("No cookie set");
+            const cookie: string = loginResponse.headers["set-cookie"][0];
+
+            // Create some tags in the database
+            await db.tag.createMany({
+                data: [{ name: "JS" }, { name: "TS" }, { name: "GraphQL" }],
+            });
+            expect(await db.tag.count()).toBe(3);
+
+            // Create a post in the database
+            const post = await db.post.createPost({
+                userId: user?.data?.data?.id,
+                title: "test",
+                content: "test",
+                status: "DRAFT",
+                category: "GENERAL",
+                postTags: ["JS"],
+            });
+            expect(await db.post.count()).toBe(1);
+
+            // Delete the post
+            const response = await axios({
+                url: "/api/posts/deletePost",
+                method: "POST",
+                headers: {
+                    Cookie: cookie,
+                },
+                data: { postId: post?.id },
+            });
+            expect(response.status).toBe(200);
+            expect(response.data.data.id).toBe(post?.id);
+            expect(await db.post.count()).toBe(0);
+        });
+
+        test("responds with 400 Bad Request when post not in database", async () => {
+            // Don't create a post for this test
+
+            // Create a user
+            await axios.post("/api/auth/register", {
+                userName: "deletepostUser",
+                email: "delete@email.com",
+                password: "Abc-1234",
+            });
+            expect(await db.user.count()).toBe(1);
+
+            // Log the user in
+            const loginResponse = await axios.post("/api/auth/login", {
+                email: "delete@email.com",
+                password: "Abc-1234",
+            });
+            expect(loginResponse.status).toBe(200);
+
+            // Get session cookie
+            if (!loginResponse.headers["set-cookie"])
+                throw new Error("No cookie set");
+            const cookie: string = loginResponse.headers["set-cookie"][0];
+
+            // Delete the post
+            const response = await axios({
+                url: "/api/posts/deletePost",
+                method: "POST",
+                headers: {
+                    Cookie: cookie,
+                },
+                data: { postId: "5e8f8f8f8f8f8f8f8f8f8f8" },
+            });
+            expect(response.status).toBe(400);
+        });
+
+        test("responds with 401 Unauthorized when not logged in", async () => {
+            // No logged in user for this test
+            // No need to create a post for this test as it should fail before the post is needed
+
+            const response = await axios.post("/api/posts/deletePost", {
+                postId: "5e8f8f8f8f8f8f8f8f8f8f8",
+            });
+            expect(response.status).toBe(401);
+        });
     });
 });

--- a/__test__/integrationTests.test.ts
+++ b/__test__/integrationTests.test.ts
@@ -784,12 +784,11 @@ describe("Integration tests for POST routes:", () => {
 
             // Delete the post
             const response = await axios({
-                url: "/api/posts/deletePost",
-                method: "POST",
+                url: `/api/posts/deletePost/${post?.id}`,
+                method: "DELETE",
                 headers: {
                     Cookie: cookie,
                 },
-                data: { postId: post?.id },
             });
             expect(response.status).toBe(200);
             expect(response.data.data.id).toBe(post?.id);
@@ -821,12 +820,11 @@ describe("Integration tests for POST routes:", () => {
 
             // Delete the post
             const response = await axios({
-                url: "/api/posts/deletePost",
-                method: "POST",
+                url: "/api/posts/deletePost/5e8f8f8f8f8f8f8f8f8f8f8",
+                method: "DELETE",
                 headers: {
                     Cookie: cookie,
                 },
-                data: { postId: "5e8f8f8f8f8f8f8f8f8f8f8" },
             });
             expect(response.status).toBe(400);
         });
@@ -835,9 +833,9 @@ describe("Integration tests for POST routes:", () => {
             // No logged in user for this test
             // No need to create a post for this test as it should fail before the post is needed
 
-            const response = await axios.post("/api/posts/deletePost", {
-                postId: "5e8f8f8f8f8f8f8f8f8f8f8",
-            });
+            const response = await axios.delete(
+                "/api/posts/deletePost/5e8f8f8f8f8f8f8f8f8f8f8"
+            );
             expect(response.status).toBe(401);
         });
     });

--- a/controllers/__test__/postController.test.ts
+++ b/controllers/__test__/postController.test.ts
@@ -346,7 +346,9 @@ describe("Unit Tests for Post Controllers", () => {
                 .fn()
                 .mockResolvedValue("deleted-post");
             const req = getMockReq({
-                postId: "test-id",
+                params: {
+                    postId: "test-id",
+                },
             });
             const { res, next } = getMockRes();
             await deletePost(mockDBGetPostById, mockDBDeletePost)(
@@ -365,7 +367,9 @@ describe("Unit Tests for Post Controllers", () => {
             const mockDBGetPostById = jest.fn().mockResolvedValue({});
             const mockDBDeletePost = jest.fn();
             const req = getMockReq({
-                postId: "test-id",
+                params: {
+                    postId: "test-id",
+                },
             });
             const { res, next } = getMockRes();
             await deletePost(mockDBGetPostById, mockDBDeletePost)(
@@ -373,7 +377,7 @@ describe("Unit Tests for Post Controllers", () => {
                 res,
                 next
             );
-            expect(mockDBDeletePost).toHaveBeenCalledWith(req.body.postId);
+            expect(mockDBDeletePost).toHaveBeenCalledWith(req.params.postId);
         });
 
         test("calls next() if an error occurs", async () => {
@@ -382,7 +386,9 @@ describe("Unit Tests for Post Controllers", () => {
                 throw new Error("error");
             });
             const req = getMockReq({
-                postId: "test-id",
+                params: {
+                    postId: "test-id",
+                },
             });
             const { res, next } = getMockRes();
             await deletePost(mockDBGetPostById, mockDBDeletePost)(
@@ -397,7 +403,9 @@ describe("Unit Tests for Post Controllers", () => {
             const mockDBGetPostById = jest.fn().mockResolvedValue(null);
             const mockDBDeletePost = jest.fn();
             const req = getMockReq({
-                postId: "test-id",
+                params: {
+                    postId: "test-id",
+                },
             });
             const { res, next } = getMockRes();
             await deletePost(mockDBGetPostById, mockDBDeletePost)(
@@ -406,7 +414,7 @@ describe("Unit Tests for Post Controllers", () => {
                 next
             );
             expect(res.status).toHaveBeenCalledWith(400);
-            expect(mockDBGetPostById).toHaveBeenCalledWith(req.body.postId);
+            expect(mockDBGetPostById).toHaveBeenCalledWith(req.params.postId);
             expect(mockDBDeletePost).not.toHaveBeenCalled();
         });
 
@@ -416,7 +424,7 @@ describe("Unit Tests for Post Controllers", () => {
                 .mockResolvedValue({ userId: "the-author" });
             const mockDBDeletePost = jest.fn();
             const req = getMockReq({
-                body: {
+                params: {
                     postId: "test-id",
                 },
                 session: {
@@ -432,7 +440,7 @@ describe("Unit Tests for Post Controllers", () => {
                 next
             );
             expect(res.status).toHaveBeenCalledWith(403);
-            expect(mockDBGetPostById).toHaveBeenCalledWith(req.body.postId);
+            expect(mockDBGetPostById).toHaveBeenCalledWith(req.params.postId);
             expect(mockDBDeletePost).not.toHaveBeenCalled();
         });
     });

--- a/controllers/postController.ts
+++ b/controllers/postController.ts
@@ -99,8 +99,10 @@ export const deletePost =
     ): RequestHandler =>
     async (req: Request, res: Response, next: NextFunction) => {
         try {
+            const { postId } = req.params;
+
             // Check if the post exists
-            const post = await DBGetPostById(req.body.postId);
+            const post = await DBGetPostById(postId);
             if (!post)
                 return res
                     .status(400)
@@ -113,7 +115,7 @@ export const deletePost =
                     message: "You are not authorised to delete this post",
                 });
 
-            const deletedPost = await DBDeletePost(req.body.postId);
+            const deletedPost = await DBDeletePost(postId);
             return res
                 .status(200)
                 .json({ status: "success", data: deletedPost });

--- a/controllers/postController.ts
+++ b/controllers/postController.ts
@@ -56,3 +56,33 @@ export const getPostById =
             return next(error);
         }
     };
+
+export const deletePost =
+    (
+        DBGetPostById: PostMethods.GetPostById,
+        DBDeletePost: PostMethods.DeletePost
+    ): RequestHandler =>
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            // Check if the post exists
+            const post = await DBGetPostById(req.body.postId);
+            if (!post)
+                return res
+                    .status(400)
+                    .json({ status: "error", message: "Post not found" });
+
+            // Check if the user is the author of the post
+            if (post.userId !== req.session?.user?.id)
+                return res.status(403).json({
+                    status: "error",
+                    message: "You are not authorised to delete this post",
+                });
+
+            const deletedPost = await DBDeletePost(req.body.postId);
+            return res
+                .status(200)
+                .json({ status: "success", data: deletedPost });
+        } catch (error) {
+            return next(error);
+        }
+    };

--- a/models/__test__/db.test.ts
+++ b/models/__test__/db.test.ts
@@ -23,6 +23,7 @@ describe("Unit Tests for Database Object:", () => {
         expect(db.post.count).toBeDefined();
         expect(db.post.createPost).toBeDefined();
         expect(db.post.getPostById).toBeDefined();
+        expect(db.post.deletePost).toBeDefined();
     });
 
     test("contains tag object with default methods", () => {

--- a/models/__test__/postModel.test.ts
+++ b/models/__test__/postModel.test.ts
@@ -1,4 +1,7 @@
 import db from "../db";
+import { prisma } from "../prisma";
+
+// Import TypeScript types
 import { UserWithoutPassword } from "../../models/userModel";
 
 jest.mock("../prisma");
@@ -118,10 +121,45 @@ describe("Unit Tests for Post Model:", () => {
             const result = await posts.getPostById("not-a-valid-id");
             expect(result).toBeNull();
         });
+
+        // TODO:
+        // Should return all related comments
+        // Should return all related likes
+
+        // Delete post
+        // -------------------------------------------------------------------------
+        describe("Delete Post:", () => {
+            test("post.deletePost returns the deleted record", async () => {
+                // Create a post in the database
+                const post = await posts.createPost({
+                    userId: user.id,
+                    title: "test",
+                    content: "test",
+                    status: "PUBLISHED",
+                    category: "GENERAL",
+                    postTags: ["JS", "TS"],
+                });
+                expect(await posts.count()).toBe(1);
+
+                // Delete the post
+                expect(await posts.deletePost(post?.id as string)).toEqual(
+                    post
+                );
+                expect(await posts.count()).toBe(0);
+                expect(
+                    await prisma.postTag.findMany({
+                        where: {
+                            postId: post?.id,
+                        },
+                    })
+                ).toHaveLength(0);
+            });
+
+            // Non-existent post results in an exception so no need to test
+
+            // test that it cascade deletes all comments and likes associated with the post once implemented
+        });
     });
 });
 
-// TODO:
-// Should return all related comments
-// Should return all related likes
 //

--- a/models/migrations/20220819042820_add_cascade_delete/migration.sql
+++ b/models/migrations/20220819042820_add_cascade_delete/migration.sql
@@ -1,0 +1,74 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `Tag` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Comments" DROP CONSTRAINT "Comments_targetCommentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Comments" DROP CONSTRAINT "Comments_targetPostId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Likes" DROP CONSTRAINT "Likes_likedPostId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Likes" DROP CONSTRAINT "Likes_likedUserId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Post" DROP CONSTRAINT "Post_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PostTag" DROP CONSTRAINT "PostTag_postId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PostTag" DROP CONSTRAINT "PostTag_tagId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ReportedContent" DROP CONSTRAINT "ReportedContent_reportedCommentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ReportedContent" DROP CONSTRAINT "ReportedContent_repostedPostId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "SavedPosts" DROP CONSTRAINT "SavedPosts_postId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "SavedPosts" DROP CONSTRAINT "SavedPosts_userId_fkey";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_name_key" ON "Tag"("name");
+
+-- AddForeignKey
+ALTER TABLE "Post" ADD CONSTRAINT "Post_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostTag" ADD CONSTRAINT "PostTag_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostTag" ADD CONSTRAINT "PostTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SavedPosts" ADD CONSTRAINT "SavedPosts_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SavedPosts" ADD CONSTRAINT "SavedPosts_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Likes" ADD CONSTRAINT "Likes_likedUserId_fkey" FOREIGN KEY ("likedUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Likes" ADD CONSTRAINT "Likes_likedPostId_fkey" FOREIGN KEY ("likedPostId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Comments" ADD CONSTRAINT "Comments_targetPostId_fkey" FOREIGN KEY ("targetPostId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Comments" ADD CONSTRAINT "Comments_targetCommentId_fkey" FOREIGN KEY ("targetCommentId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReportedContent" ADD CONSTRAINT "ReportedContent_repostedPostId_fkey" FOREIGN KEY ("repostedPostId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReportedContent" ADD CONSTRAINT "ReportedContent_reportedCommentId_fkey" FOREIGN KEY ("reportedCommentId") REFERENCES "Comments"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/models/postModel.ts
+++ b/models/postModel.ts
@@ -36,6 +36,13 @@ const Posts = (prismaPost: PrismaClient["post"]) => {
                 },
             });
         },
+        deletePost: (id) => {
+            return prismaPost.delete({
+                where: {
+                    id: id,
+                },
+            });
+        },
     };
 
     return Object.assign(prismaPost, customMethods);
@@ -47,11 +54,13 @@ export default postModel;
 export declare namespace PostMethods {
     export type CreatePost = (postData: PostData) => Promise<Post | null>;
     export type GetPostById = (id: string) => Promise<PostWithRetations | null>;
+    export type DeletePost = (id: string) => Promise<Post>;
 }
 
 interface CustomMethods {
     createPost: PostMethods.CreatePost;
     getPostById: PostMethods.GetPostById;
+    deletePost: PostMethods.DeletePost;
 }
 
 export interface PostData {

--- a/models/schema.prisma
+++ b/models/schema.prisma
@@ -41,7 +41,7 @@ model User {
 
 model Post {
     id              String            @id @default(uuid())
-    user            User              @relation(fields: [userId], references: [id])
+    user            User              @relation(fields: [userId], references: [id], onDelete: Cascade)
     userId          String
     title           String
     companyName     String?
@@ -64,25 +64,25 @@ model Post {
 
 model PostTag {
     id     String @id @default(uuid())
-    post   Post  @relation(fields: [postId], references: [id])
+    post   Post  @relation(fields: [postId], references: [id], onDelete: Cascade)
     postId String
-    tag    Tag    @relation(fields: [tagId], references: [id])
+    tag    Tag    @relation(fields: [tagId], references: [id], onDelete: Cascade)
     tagId  String
 }
 
 model SavedPosts {
     id     String @id @default(uuid())
-    user   User   @relation(fields: [userId], references: [id])
+    user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
     userId String
-    post   Post  @relation(fields: [postId], references: [id])
+    post   Post  @relation(fields: [postId], references: [id], onDelete: Cascade)
     postId String
 }
 
 model Likes {
     id          String @id @default(uuid())
-    likedUser   User   @relation(fields: [likedUserId], references: [id])
+    likedUser   User   @relation(fields: [likedUserId], references: [id], onDelete: Cascade)
     likedUserId String
-    likedPost   Post  @relation(fields: [likedPostId], references: [id])
+    likedPost   Post  @relation(fields: [likedPostId], references: [id], onDelete: Cascade)
     likedPostId String
 }
 
@@ -96,9 +96,9 @@ model Comments {
     id              String            @id @default(uuid())
     user            User              @relation(fields: [userId], references: [id])
     userId          String
-    targetPost      Post?            @relation("targetPost", fields: [targetPostId], references: [id])
+    targetPost      Post?            @relation("targetPost", fields: [targetPostId], references: [id], onDelete: Cascade)
     targetPostId    String?
-    targetComment   Post?            @relation("targetComment", fields: [targetCommentId], references: [id])
+    targetComment   Post?            @relation("targetComment", fields: [targetCommentId], references: [id], onDelete: Cascade)
     targetCommentId String?
     type            CommentType
     content         String
@@ -111,10 +111,10 @@ model ReportedContent {
     id                String      @id @default(uuid())
     reporter          User        @relation("reporter", fields: [reporterId], references: [id])
     reporterId        String
-    reportedPost      Post?      @relation(fields: [repostedPostId], references: [id])
+    reportedPost      Post?      @relation(fields: [repostedPostId], references: [id], onDelete: Cascade)
     repostedPostId    String?
     type              CommentType
-    reportedComment   Comments?   @relation(fields: [reportedCommentId], references: [id])
+    reportedComment   Comments?   @relation(fields: [reportedCommentId], references: [id], onDelete: Cascade)
     reportedCommentId String?
     createdDate       DateTime    @default(now())
     updatedDate       DateTime    @updatedAt

--- a/routes/postRoutes.ts
+++ b/routes/postRoutes.ts
@@ -29,8 +29,8 @@ router
     );
 
 router
-    .route("/deletePost")
-    .post(
+    .route("/deletePost/:postId")
+    .delete(
         protect({ loggedIn: true }),
         deletePost(db.post.getPostById, db.post.deletePost)
     );

--- a/routes/postRoutes.ts
+++ b/routes/postRoutes.ts
@@ -3,7 +3,11 @@ import db from "../models/db";
 import protect from "../middleware/routeProtector";
 
 // Import controllers
-import { createPost, getPostById } from "../controllers/postController";
+import {
+    createPost,
+    getPostById,
+    deletePost,
+} from "../controllers/postController";
 
 const router = express.Router();
 
@@ -15,5 +19,12 @@ router
     );
 
 router.route("/getPostById").post(getPostById(db.post.getPostById));
+
+router
+    .route("/deletePost")
+    .post(
+        protect({ loggedIn: true }),
+        deletePost(db.post.getPostById, db.post.deletePost)
+    );
 
 export default router;


### PR DESCRIPTION
This pull request creates a route for deleting posts with cascade deletion of related postTags and likes. Comment deletion will need to be handled separately as it will require a custom recursive query to delete all comments AND related replies