### PR TITLE
Jacob post search

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,5 +21,5 @@
             { "allowDeclarations": true }
         ]
     },
-    "ignorePatterns": ["node_modules/", "dist/"]
+    "ignorePatterns": ["node_modules/", "dist/", "util/valueEquals.js"]
 }

--- a/__test__/integrationTests.test.ts
+++ b/__test__/integrationTests.test.ts
@@ -9,8 +9,9 @@ import { Express } from "express"; // Types for Express
 import { PrismaSessionStore } from "@quixo3/prisma-session-store";
 import { Server } from "http";
 import { AxiosResponse } from "axios";
-import { RegistrationData } from "../models/userModel";
-import { UserWithoutPassword } from "../models/userModel";
+import { RegistrationData, UserWithoutPassword } from "../models/userModel";
+import { PostData, PostWithRelations } from "../models/postModel";
+import { Post, Status, Category } from ".prisma/client";
 
 jest.mock("../models/prisma");
 
@@ -661,9 +662,9 @@ describe("Integration tests for POST routes:", () => {
 
             // Create some tags in the database
             await db.tag.createMany({
-                data: [{ name: "JS" }, { name: "TS" }, { name: "GraphQL" }],
+                data: [...possibleTags.map((t) => ({ name: t }))],
             });
-            expect(await db.tag.count()).toBe(3);
+            expect(await db.tag.count()).toBe(6);
 
             const response = await axios({
                 url: "/api/posts/create",
@@ -707,9 +708,9 @@ describe("Integration tests for POST routes:", () => {
 
             // Create some tags in the database
             await db.tag.createMany({
-                data: [{ name: "JS" }, { name: "TS" }, { name: "GraphQL" }],
+                data: [...possibleTags.map((t) => ({ name: t }))],
             });
-            expect(await db.tag.count()).toBe(3);
+            expect(await db.tag.count()).toBe(6);
 
             // Create a post in the database
             const post = await db.post.createPost({
@@ -767,9 +768,9 @@ describe("Integration tests for POST routes:", () => {
 
             // Create some tags in the database
             await db.tag.createMany({
-                data: [{ name: "JS" }, { name: "TS" }, { name: "GraphQL" }],
+                data: [...possibleTags.map((t) => ({ name: t }))],
             });
-            expect(await db.tag.count()).toBe(3);
+            expect(await db.tag.count()).toBe(6);
 
             // Create a post in the database
             const post = await db.post.createPost({
@@ -871,9 +872,9 @@ describe("Integration tests for POST routes:", () => {
 
             // Create some tags in the database
             await db.tag.createMany({
-                data: [{ name: "JS" }, { name: "TS" }, { name: "GraphQL" }],
+                data: [...possibleTags.map((t) => ({ name: t }))],
             });
-            expect(await db.tag.count()).toBe(3);
+            expect(await db.tag.count()).toBe(6);
         });
 
         test("responds with 200 OK and updated post, tags, likes and comments with valid data", async () => {
@@ -989,15 +990,239 @@ describe("Integration tests for POST routes:", () => {
         // 400 Bad Request - Validation tests
     });
 
-    // test only published posts get returned
-    // test tag filter
-    // test category filter
-    // test search filter
-    // test sort default and by likes
-    // 200 OK - Successful response
+    describe("/api/posts/searchPublished", () => {
+        let searchPosts: (PostWithRelations | null)[];
+        let user: UserWithoutPassword;
+
+        beforeEach(async () => {
+            // Create a user
+            const userResponse: AxiosResponse = await axios.post(
+                "/api/auth/register",
+                {
+                    userName: "updatePostUser",
+                    email: "user@email.com",
+                    password: "Abc-1234",
+                }
+            );
+            user = userResponse.data.data;
+            expect(await db.user.count()).toBe(1);
+
+            // Create some tags in the database
+            await db.tag.createMany({
+                data: [...possibleTags.map((t) => ({ name: t }))],
+            });
+            expect(await db.tag.count()).toBe(6);
+
+            const data = [
+                {
+                    userId: user.id,
+                    title: "Using JavaScript with GraphQL",
+                    category: "LEARN" as Category,
+                    status: "PUBLISHED" as Status,
+                    postTags: ["JS", "GraphQL"],
+                    createdDate: new Date("2022-08-23T06:37:41.054Z"),
+                },
+                {
+                    userId: user.id,
+                    title: "Is JavaScript better than Java?",
+                    category: "GENERAL" as Category,
+                    status: "PUBLISHED" as Status,
+                    postTags: ["JS", "Java"],
+                    createdDate: new Date("2022-08-23T06:37:42.054Z"),
+                },
+                {
+                    userId: user.id,
+                    title: "React Developer at NTT",
+                    category: "INTERVIEW" as Category,
+                    status: "PUBLISHED" as Status,
+                    postTags: ["React"],
+                    createdDate: new Date("2022-08-23T06:37:43.054Z"),
+                },
+                {
+                    userId: user.id,
+                    title: "TypeScript is the future",
+                    category: "LEARN" as Category,
+                    status: "PUBLISHED" as Status,
+                    postTags: ["JS", "TS"],
+                    createdDate: new Date("2022-08-23T06:37:44.054Z"),
+                },
+                {
+                    userId: user.id,
+                    title: "Polymorphism in Java",
+                    category: "LEARN" as Category,
+                    status: "PUBLISHED" as Status,
+                    postTags: ["Java"],
+                    createdDate: new Date("2022-08-23T06:37:45.054Z"),
+                },
+                {
+                    userId: user.id,
+                    title: "Draft post",
+                    category: "LEARN" as Category,
+                    status: "DRAFT" as Status,
+                    postTags: ["JS", "TS"],
+                    createdDate: new Date("2022-08-23T06:37:46.054Z"),
+                },
+            ];
+
+            // Create posts in the database
+            searchPosts = await Promise.all(
+                data.map(async (p) => {
+                    return db.post.createPost(fkPostData(p));
+                })
+            );
+        });
+
+        test("responds with 200 OK and all PUBLISHED posts with no inputs", async () => {
+            const response = await axios.post(
+                "/api/posts/searchPublishedPosts"
+            );
+            expect(response.status).toBe(200);
+            expect(response.data.data.length).toBe(5);
+        });
+
+        test("responds with 200 OK and posts with 'React' tag", async () => {
+            const response = await axios.post(
+                "/api/posts/searchPublishedPosts",
+                {
+                    tags: ["React"],
+                }
+            );
+            expect(response.status).toBe(200);
+            expect(response.data.data.length).toBe(1);
+        });
+
+        test("responds with 200 OK and posts with 'React' and 'TS' tags", async () => {
+            const response = await axios.post(
+                "/api/posts/searchPublishedPosts",
+                {
+                    tags: ["React", "TS"],
+                }
+            );
+            expect(response.status).toBe(200);
+            expect(response.data.data.length).toBe(2);
+        });
+
+        test("responds with 200 OK and PUBLISHED posts from the 'LEARN' category", async () => {
+            const response = await axios.post(
+                "/api/posts/searchPublishedPosts",
+                {
+                    category: "LEARN",
+                }
+            );
+            expect(response.status).toBe(200);
+            expect(response.data.data.length).toBe(3);
+        });
+
+        test("responds with 200 OK and PUBLISHED posts matching the searched title", async () => {
+            const response = await axios.post(
+                "/api/posts/searchPublishedPosts",
+                {
+                    title: "JavaScript",
+                }
+            );
+            expect(response.status).toBe(200);
+            expect(response.data.data.length).toBe(2);
+
+            const response2 = await axios.post(
+                "/api/posts/searchPublishedPosts",
+                {
+                    title: "Using JavaScript",
+                }
+            );
+            expect(response2.status).toBe(200);
+            expect(response2.data.data.length).toBe(1);
+        });
+
+        test("responds with 200 OK and posts sorted by date DESC by default", async () => {
+            const response = await axios.post(
+                "/api/posts/searchPublishedPosts"
+            );
+            expect(response.status).toBe(200);
+            expect(response.data.data).toHaveLength(5);
+
+            // Check that date at post index i > date at post index i + 1
+            response.data.data.forEach((p: Post, i: number) => {
+                if (response.data.data[i + 1]) {
+                    expect(
+                        p.createdDate >
+                            (response.data.data[i + 1]?.createdDate as Date)
+                    ).toBe(true);
+                }
+            });
+        });
+
+        test("responds with 200 OK and posts sorted by number of likes DESC", async () => {
+            // Create 5 users to generate likes for the posts
+            const users = await Promise.all(
+                Array.from({ length: 5 }, () =>
+                    db.user.register(createRandomUserForRegister())
+                )
+            );
+            expect(await prisma.user.count()).toBe(6);
+
+            // Add likes to the posts
+            await Promise.all(
+                searchPosts.map(async (p, index) => {
+                    // Make TypeScript happy - rule out undefined values
+                    if (!p) return;
+
+                    // Build a list of likes for the post
+                    const likes = [];
+                    for (let i = 0; i < index; i++) {
+                        likes.push({
+                            userId: users[i].id,
+                            postId: p.id,
+                        });
+                    }
+
+                    // Add the likes to the database
+                    await prisma.likes.createMany({
+                        data: likes,
+                    });
+                })
+            );
+            expect(await prisma.likes.count()).toBe(15);
+
+            // Request posts with sort flag
+            const response = await axios.post(
+                "/api/posts/searchPublishedPosts",
+                {
+                    sortBy: "likes",
+                }
+            );
+            expect(response.status).toBe(200);
+            expect(response.data.data).toHaveLength(5);
+
+            // Check that number of likes at post index i > date at post index i + 1
+            response.data.data.forEach((p: PostWithRelations, i: number) => {
+                // Check that each post has more likes than the next post
+                // The conditional prevents checking the last post as it has nothing
+                // to compare to
+                if (response.data.data[i + 1]) {
+                    expect(p.likes.length).toBeGreaterThan(
+                        response.data.data[i + 1]?.likes.length
+                    );
+                }
+            });
+        });
+
+        test("responds with 404 Not Found when no matching posts exist in the database", async () => {
+            const response = await axios.post(
+                "/api/posts/searchPublishedPosts",
+                {
+                    title: "Haskell",
+                }
+            );
+            expect(response.status).toBe(404);
+        });
+    });
+
     // 400 Bad Request - Validation tests
-    // 404 Not Found - Posts not found
 });
+
+// TODO
+// Refactor - remove duplicate code for setting up tags etc.
+// Extract route integration tests to separate files
 
 // Faker
 // -------------------------------------------------------------------------
@@ -1021,3 +1246,43 @@ function createRandomUserForLogin(): LoginData {
         password: faker.internet.password(10, false, /\w/, "!Aa0"),
     };
 }
+
+const possibleTags = ["JS", "TS", "GraphQL", "React", "Vue", "Java"];
+
+/**
+ * ### fkPostData()
+ *
+ * Generates a random set of data to be used to create a post
+ * userId must be provided in the params object for the post to be created.
+ * All other fields are optional and will be generated randomly. If a field is
+ * provided in the params object, that value will be used instead of a random
+ * value.
+ *
+ * @param {Partial<PostData>} params - An object with data to be used to create a post
+ *
+ * @returns {PostData} An object with random data to be used to create a post
+ *
+ * #### Examples:
+ * ##### Generate a post with random data
+ * ```
+ * const postData = fkPostData({
+ *   userId: user.id,
+ * });
+ * ```
+ */
+const fkPostData = (params: Partial<PostData>): PostData => {
+    return {
+        userId: params?.userId as string,
+        title: faker.lorem.sentence(),
+        content: faker.lorem.paragraphs(4),
+        status: faker.helpers.arrayElement(["DRAFT", "PUBLISHED"]),
+        category: faker.helpers.arrayElement([
+            "GENERAL",
+            "LEARN",
+            "INTERVIEW",
+            "PROJECT",
+        ]),
+        postTags: faker.helpers.arrayElements(possibleTags),
+        ...params,
+    };
+};

--- a/__test__/integrationTests.test.ts
+++ b/__test__/integrationTests.test.ts
@@ -988,6 +988,15 @@ describe("Integration tests for POST routes:", () => {
         // Tests for update post
         // 400 Bad Request - Validation tests
     });
+
+    // test only published posts get returned
+    // test tag filter
+    // test category filter
+    // test search filter
+    // test sort default and by likes
+    // 200 OK - Successful response
+    // 400 Bad Request - Validation tests
+    // 404 Not Found - Posts not found
 });
 
 // Faker

--- a/controllers/postController.ts
+++ b/controllers/postController.ts
@@ -1,5 +1,5 @@
 import { RequestHandler, Request, Response, NextFunction } from "express";
-import { PostMethods, PostData } from "../models/postModel";
+import { PostMethods, PostData, QueryParams } from "../models/postModel";
 import { TagMethods } from "../models/tagModel";
 
 export const createPost =
@@ -119,6 +119,28 @@ export const deletePost =
             return res
                 .status(200)
                 .json({ status: "success", data: deletedPost });
+        } catch (error) {
+            return next(error);
+        }
+    };
+
+export const searchPublishedPosts =
+    (query: PostMethods.Search): RequestHandler =>
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const queryObject: QueryParams = {
+                status: "PUBLISHED",
+                ...req.body,
+            };
+
+            const results = await query(queryObject);
+            if (!(results.length > 0)) {
+                return res
+                    .status(404)
+                    .json({ status: "error", message: "No posts found" });
+            }
+
+            return res.status(200).json({ status: "success", data: results });
         } catch (error) {
             return next(error);
         }

--- a/controllers/postController.ts
+++ b/controllers/postController.ts
@@ -129,8 +129,8 @@ export const searchPublishedPosts =
     async (req: Request, res: Response, next: NextFunction) => {
         try {
             const queryObject: QueryParams = {
-                status: "PUBLISHED",
                 ...req.body,
+                status: "PUBLISHED",
             };
 
             const results = await query(queryObject);

--- a/models/__test__/db.test.ts
+++ b/models/__test__/db.test.ts
@@ -25,6 +25,7 @@ describe("Unit Tests for Database Object:", () => {
         expect(db.post.getPostById).toBeDefined();
         expect(db.post.updatePost).toBeDefined();
         expect(db.post.deletePost).toBeDefined();
+        expect(db.post.search).toBeDefined();
     });
 
     test("contains tag object with default methods", () => {

--- a/models/__test__/postModel.test.ts
+++ b/models/__test__/postModel.test.ts
@@ -1,10 +1,12 @@
 import db from "../db";
 import { prisma } from "../prisma";
 import { faker } from "@faker-js/faker";
+import { valueEquals } from "../../util/valueEquals";
 
 // Import TypeScript types
 import { UserWithoutPassword } from "../../models/userModel";
-import { PostData } from "../postModel";
+import { PostData, PostWithRelations } from "../postModel";
+import { Status, Category } from ".prisma/client";
 
 jest.mock("../prisma");
 
@@ -44,157 +46,386 @@ describe("Unit Tests for Post Model:", () => {
 
         // Create post
         // -------------------------------------------------------------------------
-        test("post.create creates a new post in the database", async () => {
-            expect(await posts.count()).toBe(0);
+        describe("post.create:", () => {
+            test("creates a new post in the database", async () => {
+                expect(await posts.count()).toBe(0);
 
-            await posts.createPost(
-                fkPostData({
-                    userId: user.id,
-                })
-            );
-            expect(await posts.count()).toBe(1);
+                await posts.createPost(
+                    fkPostData({
+                        userId: user.id,
+                    })
+                );
+                expect(await posts.count()).toBe(1);
 
-            const result = await posts.findFirst({
-                where: {
-                    userId: user.id,
-                },
-                include: {
-                    postTags: {
-                        include: {
-                            tag: true,
+                const result = await posts.findFirst({
+                    where: {
+                        userId: user.id,
+                    },
+                    include: {
+                        postTags: {
+                            include: {
+                                tag: true,
+                            },
                         },
                     },
-                },
+                });
+                expect(result?.postTags.length).toBeGreaterThan(0);
             });
-            expect(result?.postTags.length).toBeGreaterThan(0);
         });
 
         // Get post by id
         // -------------------------------------------------------------------------
-        test("post.getPostById returns the correct post with associated tags, comments and likes", async () => {
-            expect(await posts.count()).toBe(0);
+        describe("post.getPostById:", () => {
+            test("returns the correct post with associated tags, comments and likes", async () => {
+                expect(await posts.count()).toBe(0);
 
-            // Create some posts in the database
-            const post1 = await posts.createPost(
-                fkPostData({
-                    userId: user.id,
-                })
-            );
+                // Create some posts in the database
+                const post1 = await posts.createPost(
+                    fkPostData({
+                        userId: user.id,
+                    })
+                );
 
-            const post2 = await posts.createPost(
-                fkPostData({
-                    userId: user.id,
-                })
-            );
-            expect(await posts.count()).toBe(2);
-            expect(post1?.id).not.toEqual(post2?.id);
+                const post2 = await posts.createPost(
+                    fkPostData({
+                        userId: user.id,
+                    })
+                );
+                expect(await posts.count()).toBe(2);
+                expect(post1?.id).not.toEqual(post2?.id);
 
-            // Get post1 by id
-            const result = await posts.getPostById(post1?.id as string);
-            expect(result?.id).toBe(post1?.id);
+                // Get post1 by id
+                const result = await posts.getPostById(post1?.id as string);
+                expect(result?.id).toBe(post1?.id);
 
-            // Check that tags are included
-            expect(result?.postTags.length).toBeGreaterThan(0);
-            expect(result?.comments.length).toBe(0);
-            expect(result?.likes.length).toBe(0);
+                // Check that tags are included
+                expect(result?.postTags.length).toBeGreaterThan(0);
+                expect(result?.comments.length).toBe(0);
+                expect(result?.likes.length).toBe(0);
+            });
+
+            test("post.getpostById returns null if the post does not exist", async () => {
+                // Don't create any posts in the database for this test
+                expect(await posts.count()).toBe(0);
+
+                // Try to get a post by id
+                const result = await posts.getPostById("not-a-valid-id");
+                expect(result).toBeNull();
+            });
+
+            // TODO: get post by id
+            // Should return all related comments
+            // Should return all related likes
         });
-
-        test("post.getpostById returns null if the post does not exist", async () => {
-            // Don't create any posts in the database for this test
-            expect(await posts.count()).toBe(0);
-
-            // Try to get a post by id
-            const result = await posts.getPostById("not-a-valid-id");
-            expect(result).toBeNull();
-        });
-
-        // TODO: get post by id
-        // Should return all related comments
-        // Should return all related likes
 
         // Update post
         // -------------------------------------------------------------------------
-        test("post.updatePost updates the database and returns updated post with valid inputs", async () => {
-            // Create a post in the database
-            const postData: PostData = fkPostData({
-                userId: user.id,
-                title: "test",
-                postTags: ["JS", "TS"],
-            });
-            const post = await posts.createPost(postData);
-            expect(await posts.count()).toBe(1);
+        describe("post.updatePost:", () => {
+            test("updates the database and returns updated post with valid inputs", async () => {
+                // Create a post in the database
+                const postData: PostData = fkPostData({
+                    userId: user.id,
+                    title: "test",
+                    postTags: ["JS", "TS"],
+                });
+                const post = await posts.createPost(postData);
+                expect(await posts.count()).toBe(1);
 
-            const modifiedPost = {
-                ...postData,
-                title: "updated",
-                postTags: ["JS", "TS", "GraphQL"],
-            };
+                const modifiedPost = {
+                    ...postData,
+                    title: "updated",
+                    postTags: ["JS", "TS", "GraphQL"],
+                };
 
-            // Update the post
-            const result = await posts.updatePost(
-                post?.id as string,
-                modifiedPost
-            );
-            expect(result?.title).toBe("updated");
-            expect(result?.postTags.length).toBe(3);
-            expect(
-                result?.postTags.filter((t) => t.tag.name === "GraphQL").length
-            ).toBe(1);
-        });
-
-        test("post.updatePost returns null when the post to update can't be found", async () => {
-            const postId = "not-a-valid-id";
-            // Create a post in the database
-            const postData: PostData = fkPostData({
-                userId: user.id,
+                // Update the post
+                const result = await posts.updatePost(
+                    post?.id as string,
+                    modifiedPost
+                );
+                expect(result?.title).toBe("updated");
+                expect(result?.postTags.length).toBe(3);
+                expect(
+                    result?.postTags.filter((t) => t.tag.name === "GraphQL")
+                        .length
+                ).toBe(1);
             });
 
-            const result = await posts.updatePost(postId, postData);
-            expect(result).toBeNull();
-        });
+            test("returns null when the post to update can't be found", async () => {
+                const postId = "not-a-valid-id";
+                // Create a post in the database
+                const postData: PostData = fkPostData({
+                    userId: user.id,
+                });
 
-        // TODO: Update Post
-        // Should return all related comments
-        // Should return all related likes
+                const result = await posts.updatePost(postId, postData);
+                expect(result).toBeNull();
+            });
+
+            // TODO: Update Post
+            // Should return all related comments
+            // Should return all related likes
+        });
 
         // Delete post
         // -------------------------------------------------------------------------
-        test("post.deletePost returns the deleted record", async () => {
-            // Create a post in the database
-            const post = await posts.createPost(
-                fkPostData({
-                    userId: user.id,
-                })
-            );
-            expect(await posts.count()).toBe(1);
+        describe("post.deletePost:", () => {
+            test("returns the deleted record", async () => {
+                // Create a post in the database
+                const post = await posts.createPost(
+                    fkPostData({
+                        userId: user.id,
+                    })
+                );
+                expect(await posts.count()).toBe(1);
 
-            // Delete the post
-            expect(await posts.deletePost(post?.id as string)).toEqual(post);
-            expect(await posts.count()).toBe(0);
-            expect(
-                await prisma.postTag.findMany({
-                    where: {
-                        postId: post?.id,
+                // Delete the post
+                expect(await posts.deletePost(post?.id as string)).toEqual(
+                    post
+                );
+                expect(await posts.count()).toBe(0);
+                expect(
+                    await prisma.postTag.findMany({
+                        where: {
+                            postId: post?.id,
+                        },
+                    })
+                ).toHaveLength(0);
+            });
+
+            // Delete on a non-existent post results in an exception so no need to test it here
+
+            // TODO: Delete Post
+            // test that it cascade deletes all comments and likes associated with the post once implemented
+        });
+
+        // Search posts
+        // -------------------------------------------------------------------------
+        describe("post.searchPosts:", () => {
+            let searchPosts: (PostWithRelations | null)[];
+
+            beforeEach(async () => {
+                const data = [
+                    {
+                        userId: user.id,
+                        title: "Using JavaScript with GraphQL",
+                        category: "LEARN" as Category,
+                        status: "PUBLISHED" as Status,
+                        postTags: ["JS", "GraphQL"],
+                        createdDate: new Date("2022-08-23T06:37:41.054Z"),
                     },
-                })
-            ).toHaveLength(0);
+                    {
+                        userId: user.id,
+                        title: "Is JavaScript better than Java?",
+                        category: "GENERAL" as Category,
+                        status: "PUBLISHED" as Status,
+                        postTags: ["JS", "Java"],
+                        createdDate: new Date("2022-08-23T06:37:42.054Z"),
+                    },
+                    {
+                        userId: user.id,
+                        title: "React Developer at NTT",
+                        category: "INTERVIEW" as Category,
+                        status: "PUBLISHED" as Status,
+                        postTags: ["React"],
+                        createdDate: new Date("2022-08-23T06:37:43.054Z"),
+                    },
+                    {
+                        userId: user.id,
+                        title: "TypeScript is the future",
+                        category: "LEARN" as Category,
+                        status: "PUBLISHED" as Status,
+                        postTags: ["JS", "TS"],
+                        createdDate: new Date("2022-08-23T06:37:44.054Z"),
+                    },
+                    {
+                        userId: user.id,
+                        title: "Polymorphism in Java",
+                        category: "LEARN" as Category,
+                        status: "PUBLISHED" as Status,
+                        postTags: ["Java"],
+                        createdDate: new Date("2022-08-23T06:37:45.054Z"),
+                    },
+                    {
+                        userId: user.id,
+                        title: "Draft post",
+                        category: "LEARN" as Category,
+                        status: "DRAFT" as Status,
+                        postTags: ["JS", "TS"],
+                        createdDate: new Date("2022-08-23T06:37:46.054Z"),
+                    },
+                ];
+
+                // Create posts in the database
+                searchPosts = await Promise.all(
+                    data.map(async (p) => {
+                        return posts.createPost(fkPostData(p));
+                    })
+                );
+            });
+
+            test("returns all published posts when no category or filters provided", async () => {
+                const queryObject = {};
+                const results = await posts.search(queryObject);
+
+                // Filter and sort arrays for comparison
+                results.sort((a, b) => (a.id < b.id ? -1 : 1));
+                searchPosts = searchPosts.filter(
+                    (p) => p?.status === "PUBLISHED"
+                );
+                searchPosts.sort((a, b) => {
+                    if (a && b) return a.id < b.id ? -1 : 1;
+                    return 0;
+                });
+                expect(valueEquals(results, searchPosts)).toBe(true);
+            });
+
+            test("returns all posts for the given category", async () => {
+                const queryObject = {
+                    category: "LEARN" as Category,
+                };
+                const results = await posts.search(queryObject);
+
+                // No need to sort as number of results will suffice
+                expect(results.length).toBe(3);
+            });
+
+            test("returns DRAFT || ALL posts when status flag given", async () => {
+                // PUBLISHED status tested above so not tested here
+
+                // DRAFT posts
+                const queryObject = {
+                    status: "DRAFT",
+                };
+                const results = await posts.search(queryObject);
+                expect(results).toHaveLength(1);
+
+                // ALL posts
+                const queryObject2 = {
+                    status: "ALL",
+                };
+                const results2 = await posts.search(queryObject2);
+                expect(results2).toHaveLength(6);
+            });
+
+            test("returns all posts with a matching title", async () => {
+                const queryObject = {
+                    title: "JavaScript",
+                };
+                const results = await posts.search(queryObject);
+                expect(results).toHaveLength(2);
+
+                const queryObject2 = {
+                    title: "Using JavaScript",
+                };
+                const results2 = await posts.search(queryObject2);
+                expect(results2).toHaveLength(1);
+            });
+
+            test("returns all PUBLISHED posts with the given tags", async () => {
+                // Query with no tags tested in a previous test
+
+                // Test with one tag
+                const queryObject = {
+                    tags: ["React"],
+                };
+                const results = await posts.search(queryObject);
+                expect(results).toHaveLength(1);
+
+                // Test with multiple tags
+                const queryObject2 = {
+                    tags: ["React", "TS"],
+                };
+                const results2 = await posts.search(queryObject2);
+                // Only returns 2 posts as one of the posts with the 'TS' tag is a draft
+                expect(results2).toHaveLength(2);
+            });
+
+            test("sorts results by date DESC by default and by likes DESC with sortBy flag", async () => {
+                // Create 5 users to generate likes for the posts
+                const users = await Promise.all(
+                    Array.from({ length: 5 }, () =>
+                        db.user.register({
+                            userName: faker.internet.userName(),
+                            email: faker.internet.email(),
+                            password: "Abc-123",
+                        })
+                    )
+                );
+
+                // Add likes to the posts
+                await Promise.all(
+                    searchPosts.map(async (p, index) => {
+                        // Make TypeScript happy - rule out undefined values
+                        if (!p) return;
+
+                        // Build a list of likes for the post
+                        const likes = [];
+                        for (let i = 0; i < index; i++) {
+                            likes.push({
+                                userId: users[i].id,
+                                postId: p.id,
+                            });
+                        }
+
+                        // Add the likes to the database
+                        await prisma.likes.createMany({
+                            data: likes,
+                        });
+                    })
+                );
+                expect(await prisma.likes.count()).toBe(15);
+
+                // Test default behaviour: Sort by date DESC
+                const queryObject = {};
+                const results = await posts.search(queryObject);
+                expect(results).toHaveLength(5);
+
+                // Filter and sort searchPosts by date DESC so we can compare to actual
+                // results from the database
+                searchPosts = searchPosts.filter(
+                    (p) => p?.status === "PUBLISHED"
+                );
+                searchPosts.sort((a, b) => {
+                    if (a && b) return a.createdDate > b.createdDate ? -1 : 1;
+                    return 0;
+                });
+
+                results.forEach((p, i) => {
+                    expect(p.id).toBe(searchPosts[i]?.id);
+                });
+
+                // Test with sortBy = "likes" flag
+                const queryObject2 = {
+                    sortBy: "likes",
+                };
+                const results2 = await posts.search(queryObject2);
+                expect(results2).toHaveLength(5);
+
+                results.forEach((p, i) => {
+                    // Check that each post has more likes than the next post
+                    // The conditional prevents checking the last post as it has nothing
+                    // to compare to
+                    if (results[i + 1]) {
+                        expect(p.likes.length).toBeGreaterThan(
+                            results[i + 1]?.likes.length
+                        );
+                    }
+                });
+            });
+
+            test("returns an empty array if no results found", async () => {
+                // Delete all posts from the database
+                await posts.deleteMany({});
+
+                // Search for all posts
+                const queryObject = {};
+                const results = await posts.search(queryObject);
+                expect(results).toEqual([]);
+            });
+
+            // TODO: Search
+            // returns null if no results found
         });
-
-        // Delete on a non-existent post results in an exception so no need to test it here
-
-        // TODO: Delete Post
-        // test that it cascade deletes all comments and likes associated with the post once implemented
-
-        test("post.search returns all published posts when no category provided", () => {
-            expect(posts.search()).toBe("results"); //posts.findMany({ where: { status: "PUBLISHED" } }));
-        });
-
-        // TODO: Search
-        // returns all posts for the given category || all posts
-        // only returns posts with status of PUBLISHED
-        // correctly filters posts by tag
-        // correctly filters posts by title search query
-        // correctly sorts posts by date (default) or number of likes (if sortBy is "likes")
     });
 });
 

--- a/models/__test__/postModel.test.ts
+++ b/models/__test__/postModel.test.ts
@@ -1,5 +1,6 @@
 import db from "../db";
 import { prisma } from "../prisma";
+import { faker } from "@faker-js/faker";
 
 // Import TypeScript types
 import { UserWithoutPassword } from "../../models/userModel";
@@ -210,7 +211,30 @@ describe("Unit Tests for Post Model:", () => {
 
         // TODO: Delete Post
         // test that it cascade deletes all comments and likes associated with the post once implemented
+        
+        test("post.search returns all published posts when no category provided", () => {
+            expect(posts.search()).toBe("results"); //posts.findMany({ where: { status: "PUBLISHED" } }));
+        });
+
+        // TODO: Search
+        // returns all posts for the given category || all posts
+        // only returns posts with status of PUBLISHED
+        // correctly filters posts by tag
+        // correctly filters posts by title search query
+        // correctly sorts posts by date (default) or number of likes (if sortBy is "likes")
     });
 });
 
-//
+// Faker
+// -------------------------------------------------------------------------
+
+// const fkCreatePost = (): PostData => {
+//     return {
+//         userId: faker.unique(faker.datatype.uuid) as string,
+//         title: faker.lorem.sentence(),
+//         content: faker.lorem.paragraphs(4),
+//         status: faker.random.arrayElement(["DRAFT", "PUBLISHED"]),
+//         category: faker.random.arrayElement(["GENERAL", "TECHNOLOGY", "BUSINESS"]),
+//         postTags: [faker.random.uuid(), faker.random.uuid()],
+//     };
+// }

--- a/models/__test__/postModel.test.ts
+++ b/models/__test__/postModel.test.ts
@@ -424,7 +424,6 @@ describe("Unit Tests for Post Model:", () => {
             });
 
             // TODO: Search
-            // returns null if no results found
         });
     });
 });

--- a/models/migrations/20220823060430_update_likes_schema/migration.sql
+++ b/models/migrations/20220823060430_update_likes_schema/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `likedPostId` on the `Likes` table. All the data in the column will be lost.
+  - You are about to drop the column `likedUserId` on the `Likes` table. All the data in the column will be lost.
+  - Added the required column `postId` to the `Likes` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userId` to the `Likes` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Likes" DROP CONSTRAINT "Likes_likedPostId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Likes" DROP CONSTRAINT "Likes_likedUserId_fkey";
+
+-- AlterTable
+ALTER TABLE "Likes" DROP COLUMN "likedPostId",
+DROP COLUMN "likedUserId",
+ADD COLUMN     "postId" TEXT NOT NULL,
+ADD COLUMN     "userId" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Likes" ADD CONSTRAINT "Likes_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Likes" ADD CONSTRAINT "Likes_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/models/postModel.ts
+++ b/models/postModel.ts
@@ -85,6 +85,7 @@ const Posts = (prismaPost: PrismaClient["post"]) => {
                 },
             });
         },
+        search: () => "results",
     };
 
     return Object.assign(prismaPost, customMethods);
@@ -101,6 +102,7 @@ export declare namespace PostMethods {
         postData: PostData
     ) => Promise<PostWithRelations | null>;
     export type DeletePost = (id: string) => Promise<Post>;
+    export type Search = () => string;
 }
 
 interface CustomMethods {
@@ -108,6 +110,7 @@ interface CustomMethods {
     getPostById: PostMethods.GetPostById;
     updatePost: PostMethods.UpdatePost;
     deletePost: PostMethods.DeletePost;
+    search: PostMethods.Search;
 }
 
 export interface PostData {

--- a/models/postModel.ts
+++ b/models/postModel.ts
@@ -1,4 +1,4 @@
-import { Prisma, PrismaClient, Post, Status, Category } from "@prisma/client";
+import { Prisma, PrismaClient, Status, Category } from "@prisma/client";
 import { prisma } from "./prisma";
 
 const getTagIds = async (postTags: string[]) => {
@@ -12,16 +12,24 @@ const getTagIds = async (postTags: string[]) => {
 const Posts = (prismaPost: PrismaClient["post"]) => {
     const customMethods: CustomMethods = {
         createPost: async (postData) => {
-            const tagIds = getTagIds(postData.postTags);
-
+            const tagIds = await getTagIds(postData.postTags);
             return prismaPost.create({
                 data: {
                     ...postData,
                     postTags: {
                         createMany: {
-                            data: await tagIds,
+                            data: tagIds,
                         },
                     },
+                },
+                include: {
+                    postTags: {
+                        include: {
+                            tag: true,
+                        },
+                    },
+                    likes: true,
+                    comments: true,
                 },
             });
         },
@@ -83,9 +91,58 @@ const Posts = (prismaPost: PrismaClient["post"]) => {
                 where: {
                     id: id,
                 },
+                include: {
+                    postTags: {
+                        include: {
+                            tag: true,
+                        },
+                    },
+                    likes: true,
+                    comments: true,
+                },
             });
         },
-        search: () => "results",
+        search: async ({ category, status, title, tags, sortBy }) => {
+            // Get tag objects from tag names
+            const tagObjs = tags ? await getTagIds(tags) : null;
+
+            return prismaPost.findMany({
+                where: {
+                    ...(category ? { category: category } : {}),
+                    ...(status === "ALL"
+                        ? {}
+                        : status === "DRAFT"
+                        ? { status: "DRAFT" }
+                        : { status: "PUBLISHED" }),
+                    ...(title ? { title: { contains: title } } : {}),
+                    ...(tags
+                        ? {
+                              postTags: {
+                                  some: {
+                                      tagId: {
+                                          in: tagObjs?.map((tag) => tag.tagId),
+                                      },
+                                  },
+                              },
+                          }
+                        : {}),
+                },
+                include: {
+                    postTags: {
+                        include: {
+                            tag: true,
+                        },
+                    },
+                    likes: true,
+                    comments: true,
+                },
+                orderBy: {
+                    ...(sortBy === "likes"
+                        ? { likes: { _count: "desc" } }
+                        : { createdDate: "desc" }),
+                },
+            });
+        },
     };
 
     return Object.assign(prismaPost, customMethods);
@@ -95,14 +152,18 @@ const postModel = Posts(prisma.post);
 export default postModel;
 
 export declare namespace PostMethods {
-    export type CreatePost = (postData: PostData) => Promise<Post | null>;
+    export type CreatePost = (
+        postData: PostData
+    ) => Promise<PostWithRelations | null>;
     export type GetPostById = (id: string) => Promise<PostWithRelations | null>;
     export type UpdatePost = (
         id: string,
         postData: PostData
     ) => Promise<PostWithRelations | null>;
-    export type DeletePost = (id: string) => Promise<Post>;
-    export type Search = () => string;
+    export type DeletePost = (id: string) => Promise<PostWithRelations>;
+    export type Search = (
+        queryParams: QueryParams
+    ) => Promise<PostWithRelations[]>;
 }
 
 interface CustomMethods {
@@ -125,6 +186,14 @@ export interface PostData {
     position?: string;
     jobAdUrl?: string;
     postTags: string[];
+}
+
+export interface QueryParams {
+    category?: Category;
+    status?: string;
+    title?: string;
+    tags?: string[];
+    sortBy?: string;
 }
 
 // Define type for posts including relationships to tags, likes and comments

--- a/models/schema.prisma
+++ b/models/schema.prisma
@@ -80,10 +80,10 @@ model SavedPosts {
 
 model Likes {
     id          String @id @default(uuid())
-    likedUser   User   @relation(fields: [likedUserId], references: [id], onDelete: Cascade)
-    likedUserId String
-    likedPost   Post  @relation(fields: [likedPostId], references: [id], onDelete: Cascade)
-    likedPostId String
+    user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+    userId String
+    post   Post  @relation(fields: [postId], references: [id], onDelete: Cascade)
+    postId String
 }
 
 model Tag {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "express-rate-limit": "^6.5.1",
                 "express-session": "^1.17.3",
                 "prisma": "^4.0.0",
+                "undefine": "^0.2.14",
                 "uuid": "^8.3.2",
                 "yup": "^0.32.11"
             },
@@ -6120,6 +6121,14 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/undefine": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/undefine/-/undefine-0.2.14.tgz",
+            "integrity": "sha512-jDeuMdEIFsW7v7zret+FfJeqhguWCirxo/XYGmqgqyEajrPY1lYwhJKUs0aXFGYS58SLAewZ9ejsl8fZcFpphQ==",
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
         "node_modules/unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -10894,6 +10903,11 @@
             "requires": {
                 "random-bytes": "~1.0.0"
             }
+        },
+        "undefine": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/undefine/-/undefine-0.2.14.tgz",
+            "integrity": "sha512-jDeuMdEIFsW7v7zret+FfJeqhguWCirxo/XYGmqgqyEajrPY1lYwhJKUs0aXFGYS58SLAewZ9ejsl8fZcFpphQ=="
         },
         "unpipe": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
     "dependencies": {
         "@prisma/client": "^4.0.0",
         "@quixo3/prisma-session-store": "^3.1.8",
-        "cors": "^2.8.5",
-        "express-rate-limit": "^6.5.1",
         "bcrypt": "^5.0.1",
+        "cors": "^2.8.5",
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
+        "express-rate-limit": "^6.5.1",
         "express-session": "^1.17.3",
         "prisma": "^4.0.0",
+        "undefine": "^0.2.14",
         "uuid": "^8.3.2",
         "yup": "^0.32.11"
     },

--- a/routes/postRoutes.ts
+++ b/routes/postRoutes.ts
@@ -30,7 +30,7 @@ router
 
 router
     .route("/deletePost")
-    .post(
+    .delete(
         protect({ loggedIn: true }),
         deletePost(db.post.getPostById, db.post.deletePost)
     );

--- a/routes/postRoutes.ts
+++ b/routes/postRoutes.ts
@@ -8,6 +8,7 @@ import {
     getPostById,
     updatePost,
     deletePost,
+    searchPublishedPosts,
 } from "../controllers/postController";
 
 const router = express.Router();
@@ -34,5 +35,9 @@ router
         protect({ loggedIn: true }),
         deletePost(db.post.getPostById, db.post.deletePost)
     );
+
+router
+    .route("/searchPublishedPosts")
+    .post(searchPublishedPosts(db.post.search));
 
 export default router;

--- a/util/valueEquals.js
+++ b/util/valueEquals.js
@@ -1,0 +1,230 @@
+/* istanbul ignore file */
+
+/**
+ * This file contains the valueEquals function created by Jean Vincent as
+ * part of the toubkal project. The original file can be found at:
+ * https://github.com/ReactiveSets/toubkal/blob/master/lib/util/value_equals.js
+
+    value_equals.js
+    
+    The MIT License (MIT)
+    
+    Copyright (c) 2013-2020, Reactive Sets
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+var toString = Object.prototype.toString;
+
+/* --------------------------------------------------------------------------
+      @function value_equals( a, b, enforce_properties_order, cyclic )
+      
+      @short Returns true if a and b are deeply equal, false otherwise.
+      
+      @parameters
+      - **a** (Any type): value to compare to ```b```
+      - **b** (Any type): value compared to ```a```
+      - **enforce_properties_order** (Boolean): true to check if Object
+        properties are provided in the same order between ```a``` and
+        ```b```
+      - **cyclic** (Boolean): true to check for cycles in cyclic objects
+      
+      @description
+      Implementation:
+      ```a``` is considered equal to ```b``` if all scalar values in
+      a and b are strictly equal as compared with operator '===' except
+      for these two special cases:
+      - ```0 === -0``` but are not considered equal by value_equals().
+      - ```NaN``` is not equal to itself but is considered equal by
+      value_equals().
+      
+      ```RegExp``` objects must have the same ```lastIndex``` to be
+      considered equal. i.e. both regular expressions have matched
+      the same number of times.
+      
+      Functions must be identical, so that they have the same closure
+      context.
+      
+      ```undefined``` is a valid value, including in Objects
+      
+      This function is checked by 106 CI tests.
+      
+      Provide options for slower, less-common use cases:
+      
+      - Unless enforce_properties_order is true, if ```a``` and ```b```
+        are non-Array Objects, the order of occurence of their attributes
+        is considered irrelevant: ```{ a: 1, b: 2 }``` is considered equal
+        to ```{ b: 2, a: 1 }```.
+      
+      - Unless cyclic is true, Cyclic objects will throw a
+        ```RangeError``` exception: ```"Maximum call stack size exceeded"```
+  */
+export const valueEquals = function equals(
+    a,
+    b,
+    enforce_properties_order,
+    cyclic
+) {
+    return (
+        (a === b && // strick equality should be enough unless zero
+            a !== 0) || // because 0 === -0, requires test by _equals()
+        _equals(a, b) // handles not strictly equal or zero values
+    );
+
+    function _equals(a, b) {
+        // a and b have already failed test for strict equality or are zero
+
+        var s, l, p, x, y;
+
+        // They should have the same toString() signature
+        if ((s = toString.call(a)) !== toString.call(b)) return false;
+
+        switch (s) {
+            default: // Boolean, Date, String
+                return a.valueOf() === b.valueOf();
+
+            case "[object Number]":
+                // Converts Number instances into primitive values
+                // This is required also for NaN test bellow
+                a = +a;
+                b = +b;
+
+                return a // a is Non-zero and Non-NaN
+                    ? a === b
+                    : // a is 0, -0 or NaN
+                    a === a // a is 0 or -O
+                    ? 1 / a === 1 / b // 1/0 !== 1/-0 because Infinity !== -Infinity
+                    : b !== b; // NaN, the only Number not equal to itself!
+            // [object Number]
+
+            case "[object RegExp]":
+                return (
+                    a.source == b.source &&
+                    a.global == b.global &&
+                    a.ignoreCase == b.ignoreCase &&
+                    a.multiline == b.multiline &&
+                    a.lastIndex == b.lastIndex
+                );
+            // [object RegExp]
+
+            case "[object Function]":
+                return false; // functions should be strictly equal because of closure context
+            // [object Function]
+
+            case "[object Array]":
+                if (cyclic && (x = reference_equals(a, b)) !== null) return x; // intentionally duplicated bellow for [object Object]
+
+                if ((l = a.length) != b.length) return false;
+                // Both have as many elements
+
+                while (l--) {
+                    if (((x = a[l]) === (y = b[l]) && x !== 0) || _equals(x, y))
+                        continue;
+
+                    return false;
+                }
+
+                return true;
+            // [object Array]
+
+            case "[object Object]":
+                if (cyclic && (x = reference_equals(a, b)) !== null) return x; // intentionally duplicated from above for [object Array]
+
+                l = 0; // counter of own properties
+
+                if (enforce_properties_order) {
+                    var properties = [];
+
+                    for (p in a) {
+                        if (a.hasOwnProperty(p)) {
+                            properties.push(p);
+
+                            if (
+                                ((x = a[p]) === (y = b[p]) && x !== 0) ||
+                                _equals(x, y)
+                            )
+                                continue;
+
+                            return false;
+                        }
+                    }
+
+                    // Check if 'b' has as the same properties as 'a' in the same order
+                    for (p in b)
+                        if (b.hasOwnProperty(p) && properties[l++] != p)
+                            return false;
+                } else {
+                    for (p in a) {
+                        if (a.hasOwnProperty(p)) {
+                            ++l;
+
+                            if (
+                                ((x = a[p]) === (y = b[p]) && x !== 0) ||
+                                _equals(x, y)
+                            )
+                                continue;
+
+                            return false;
+                        }
+                    }
+
+                    // Check if 'b' has as not more own properties than 'a'
+                    for (p in b)
+                        if (b.hasOwnProperty(p) && --l < 0) return false;
+                }
+
+                return true;
+            // [object Object]
+        } // switch toString.call( a )
+    } // _equals()
+
+    /* -----------------------------------------------------------------------------------------
+       reference_equals( a, b )
+       
+       Helper function to compare object references on cyclic objects or arrays.
+       
+       Returns:
+         - null if a or b is not part of a cycle, adding them to object_references array
+         - true: same cycle found for a and b
+         - false: different cycle found for a and b
+       
+       On the first call of a specific invocation of equal(), replaces self with inner function
+       holding object_references array object in closure context.
+       
+       This allows to create a context only if and when an invocation of equal() compares
+       objects or arrays.
+    */
+    function reference_equals(a, b) {
+        var object_references = [];
+
+        return (reference_equals = _reference_equals)(a, b);
+
+        function _reference_equals(a, b) {
+            var l = object_references.length;
+
+            while (l--)
+                if (object_references[l--] === b)
+                    return object_references[l] === a;
+
+            object_references.push(a, b);
+
+            return null;
+        } // _reference_equals()
+    } // reference_equals()
+}; // equals()
+// value_equals.js


### PR DESCRIPTION
Added support for searching posts dynamically.
- Model + custom methods
- Controller
- Route handler

This PR adds the ability to search any published posts in the database. Login is not required (any user can search posts).
Search queries are performed by passing an object with search parameters in the body of the request.

Posts are sorted by date (default behaviour) or by number of likes if the sortBy flag is set to "likes" in the request body:
```
body: {
    sortBy: "likes"
}
```

The following query parameters are currently supported:

**title**: string - a search parameter for matching a search string to post titles. eg. "JavaScript" - this is currently a naive implementation which will search for the exact string. We can look to implement a more powerful search algorithm in future which splits the search string terms and searches for 'best fit' results.

**tags**: string[] - an array of the tags to filter the posts by. eg. ["Java", "TypeScript", "React"].

**sortBy**: string - only accepts "likes" at the moment - default is "date" - all results are currently sorted in DESC order. In future we can add the ability to change the order, though this isn't a critical feature.

**category**: Category - Limits search results to posts from the matching category.

***status***: Status | "ALL" - Limits search results to published, draft or all posts. ***This feature exists in the search query method to make it easy to implement getting/searching draft or all posts in future. The searchPublishedPosts controller automatically sets the status attribute making it impossible to include draft posts with this route***.